### PR TITLE
planner: remove redundant checks for preconditions.

### DIFF
--- a/planner_test.go
+++ b/planner_test.go
@@ -8,25 +8,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func stateIsPresent(w gop.Stack, s ...gop.State) bool {
+	ok, _, _ := gop.StatesArePresent(w, s)
+	return ok
+}
+
 func TestStatesArePresent(t *testing.T) {
-	w := gop.NewStack()
-	w.Push(S(1))
-	w.Push(S(2))
-	w.Push(S(3))
+	w := stack(1, 2, 3)
 
 	// Correct assertions
-	assert.True(t, gop.StatesArePresent(w, S(1)))
-	assert.True(t, gop.StatesArePresent(w, S(2)))
-	assert.True(t, gop.StatesArePresent(w, S(3)))
-	assert.True(t, gop.StatesArePresent(w, S(1), S(2)))
-	assert.True(t, gop.StatesArePresent(w, S(1), S(3)))
-	assert.True(t, gop.StatesArePresent(w, S(3), S(2)))
-	assert.True(t, gop.StatesArePresent(w, S(3), S(1)))
-	assert.True(t, gop.StatesArePresent(w, S(2), S(1), S(3)))
+	assert.True(t, stateIsPresent(w, S(1)))
+	assert.True(t, stateIsPresent(w, S(2)))
+	assert.True(t, stateIsPresent(w, S(3)))
+	assert.True(t, stateIsPresent(w, S(1), S(2)))
+	assert.True(t, stateIsPresent(w, S(1), S(3)))
+	assert.True(t, stateIsPresent(w, S(3), S(2)))
+	assert.True(t, stateIsPresent(w, S(3), S(1)))
+	assert.True(t, stateIsPresent(w, S(2), S(1), S(3)))
 
-	// Missing states.
-	assert.False(t, gop.StatesArePresent(w, S(5)))
-	assert.False(t, gop.StatesArePresent(w, S(1), S(5)))
+	//// Missing states.
+	assert.False(t, stateIsPresent(w, S(5)))
+	assert.False(t, stateIsPresent(w, S(1), S(5)))
 }
 
 func TestEqualStacks(t *testing.T) {


### PR DESCRIPTION
```
benchmark                       old ns/op     new ns/op     delta
BenchmarkBuildPlan4steps-4      35622         36809         +3.33%
BenchmarkBuildPlan8steps-4      75909         76410         +0.66%
BenchmarkBuildPlan16steps-4     158993        153373        -3.53%
BenchmarkBuildPlan32steps-4     333063        310948        -6.64%

benchmark                       old allocs     new allocs     delta
BenchmarkBuildPlan4steps-4      293            301            +2.73%
BenchmarkBuildPlan8steps-4      608            624            +2.63%
BenchmarkBuildPlan16steps-4     1232           1264           +2.60%
BenchmarkBuildPlan32steps-4     2483           2547           +2.58%

benchmark                       old bytes     new bytes     delta
BenchmarkBuildPlan4steps-4      4905          5177          +5.55%
BenchmarkBuildPlan8steps-4      10538         11130         +5.62%
BenchmarkBuildPlan16steps-4     20269         21501         +6.08%
BenchmarkBuildPlan32steps-4     42802         45315         +5.87%
```

With benchmarks:

```
PASS
ok      github.com/alevinval/gop        0.013s
BenchmarkBuildPlan4steps-4         50000             36809 ns/op            5177 B/op        301 allocs/op
BenchmarkBuildPlan8steps-4         20000             76410 ns/op           11130 B/op        624 allocs/op
BenchmarkBuildPlan16steps-4        10000            153373 ns/op           21501 B/op       1264 allocs/op
BenchmarkBuildPlan32steps-4         5000            310948 ns/op           45315 B/op       2547 allocs/op
PASS
ok      github.com/alevinval/gop/benchmarks     7.635s
?       github.com/alevinval/gop/example        [no test files]
```